### PR TITLE
Fix address calculation in ulp_run() call in all examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ static void init_run_ulp(uint32_t usec) {
     // use this binary loader instead
     esp_err_t err = ulptool_load_binary(0, ulp_main_bin_start, (ulp_main_bin_end - ulp_main_bin_start) / sizeof(uint32_t));
     // ulp coprocessor will run on its own now
-    err = ulp_run((&ulp_entry - RTC_SLOW_MEM) / sizeof(uint32_t));
+    err = ulp_run(&ulp_entry - RTC_SLOW_MEM);
 }
 ```
 
@@ -141,7 +141,7 @@ void loop() {
 static void init_run_ulp(uint32_t usec) {
   ulp_set_wakeup_period(0, usec);
   esp_err_t err = ulptool_load_binary(0, ulp_main_bin_start, (ulp_main_bin_end - ulp_main_bin_start) / sizeof(uint32_t));
-  err = ulp_run((&ulp_entry - RTC_SLOW_MEM) / sizeof(uint32_t));
+  err = ulp_run(&ulp_entry - RTC_SLOW_MEM);
 
   if (err) Serial.println("Error Starting ULP Coprocessor");
 }

--- a/src/ulp_examples/ulp_README/ulp_README.ino
+++ b/src/ulp_examples/ulp_README/ulp_README.ino
@@ -28,6 +28,6 @@ static void init_run_ulp(uint32_t usec) {
     esp_err_t err = ulptool_load_binary(0, ulp_main_bin_start, (ulp_main_bin_end - ulp_main_bin_start) / sizeof(uint32_t));
     // ulp coprocessor will run on its own now
     ulp_count = 0;
-    err = ulp_run((&ulp_entry - RTC_SLOW_MEM) / sizeof(uint32_t));
+    err = ulp_run(&ulp_entry - RTC_SLOW_MEM);
     if (err) Serial.println("Error Starting ULP Coprocessor");
 }

--- a/src/ulp_examples/ulp_adc/ulp_adc.ino
+++ b/src/ulp_examples/ulp_adc/ulp_adc.ino
@@ -73,6 +73,6 @@ static void init_ulp_program()
 static void start_ulp_program()
 {
   /* Start the program */
-  esp_err_t err = ulp_run((&ulp_entry - RTC_SLOW_MEM) / sizeof(uint32_t));
+  esp_err_t err = ulp_run(&ulp_entry - RTC_SLOW_MEM);
   ESP_ERROR_CHECK(err);
 }

--- a/src/ulp_examples/ulp_hall_sensor/ulp_hall_sensor.ino
+++ b/src/ulp_examples/ulp_hall_sensor/ulp_hall_sensor.ino
@@ -49,7 +49,7 @@ void setup() {
 
   Serial.printf("Entering deep sleep\n\n");
   /* Start the ULP program */
-  ESP_ERROR_CHECK( ulp_run((&ulp_entry - RTC_SLOW_MEM) / sizeof(uint32_t)));
+  ESP_ERROR_CHECK( ulp_run(&ulp_entry - RTC_SLOW_MEM) );
   ESP_ERROR_CHECK( esp_sleep_enable_ulp_wakeup() );
   esp_deep_sleep_start();
 }

--- a/src/ulp_examples/ulp_i2c_bitbang/ulp_i2c_bitbang.ino
+++ b/src/ulp_examples/ulp_i2c_bitbang/ulp_i2c_bitbang.ino
@@ -89,6 +89,6 @@ static void init_ulp_program()
 static void start_ulp_program()
 {
   /* Start the program */
-  esp_err_t err = ulp_run((&ulp_entry - RTC_SLOW_MEM) / sizeof(uint32_t));
+  esp_err_t err = ulp_run(&ulp_entry - RTC_SLOW_MEM);
   ESP_ERROR_CHECK(err);
 }

--- a/src/ulp_examples/ulp_rtc_gpio/ulp_rtc_gpio.ino
+++ b/src/ulp_examples/ulp_rtc_gpio/ulp_rtc_gpio.ino
@@ -79,7 +79,7 @@ void setup() {
 
   Serial.printf("Entering deep sleep\n\n");
   /* Start the ULP program */
-  ESP_ERROR_CHECK( ulp_run((&ulp_entry - RTC_SLOW_MEM) / sizeof(uint32_t)));
+  ESP_ERROR_CHECK( ulp_run(&ulp_entry - RTC_SLOW_MEM) );
   ESP_ERROR_CHECK( esp_sleep_enable_ulp_wakeup() );
   rtc_gpio_set_level(cpu_up_num, 0);
   esp_deep_sleep_start();

--- a/src/ulp_examples/ulp_tsens/ulp_tsens.ino
+++ b/src/ulp_examples/ulp_tsens/ulp_tsens.ino
@@ -43,7 +43,7 @@ void setup() {
 
     Serial.printf("Entering deep sleep\n\n");
     /* Start the ULP program */
-    ESP_ERROR_CHECK( ulp_run((&ulp_entry - RTC_SLOW_MEM) / sizeof(uint32_t)));
+    ESP_ERROR_CHECK( ulp_run(&ulp_entry - RTC_SLOW_MEM) );
     ESP_ERROR_CHECK( esp_sleep_enable_ulp_wakeup() );
     esp_deep_sleep_start();
 }

--- a/src/ulp_examples/ulp_watering_device/ulp_watering_device.ino
+++ b/src/ulp_examples/ulp_watering_device/ulp_watering_device.ino
@@ -106,6 +106,6 @@ static void start_ulp_program()
   ulp_sample_counter = 0;
 
   /* Start the program */
-  esp_err_t err = ulp_run((&ulp_entry - RTC_SLOW_MEM) / sizeof(uint32_t));
+  esp_err_t err = ulp_run(&ulp_entry - RTC_SLOW_MEM);
   ESP_ERROR_CHECK(err);
 }

--- a/src/ulp_examples/ulpcc/ulpcc_adc/ulpcc_adc.ino
+++ b/src/ulp_examples/ulpcc/ulpcc_adc/ulpcc_adc.ino
@@ -48,6 +48,6 @@ static void init_run_ulp(uint32_t usec) {
   // all shared ulp variables have to be intialized after ulptool_load_binary for the ulp to see it.
   // Set the high threshold reading you want the ulp to trigger a main processor wakeup.
   ulp_threshold = 0x20;
-  err = ulp_run((&ulp_entry - RTC_SLOW_MEM) / sizeof(uint32_t));
+  err = ulp_run(&ulp_entry - RTC_SLOW_MEM);
   if (err) Serial.println("Error Starting ULP Coprocessor");
 }

--- a/src/ulp_examples/ulpcc/ulpcc_counter/ulpcc_counter.ino
+++ b/src/ulp_examples/ulpcc/ulpcc_counter/ulpcc_counter.ino
@@ -25,7 +25,7 @@ void loop() {
 static void init_run_ulp(uint32_t usec) {
   ulp_set_wakeup_period(0, usec);
   esp_err_t err = ulptool_load_binary(0, ulp_main_bin_start, (ulp_main_bin_end - ulp_main_bin_start) / sizeof(uint32_t));
-  err = ulp_run((&ulp_entry - RTC_SLOW_MEM) / sizeof(uint32_t));
+  err = ulp_run(&ulp_entry - RTC_SLOW_MEM);
   
   if (err) Serial.println("Error Starting ULP Coprocessor");
 }


### PR DESCRIPTION
**FAQ**

**But all the examples work without this change?**
_When entry is the first record in the code, `&ulp_entry - RTC_SLOW_MEM == 0`, so any multiplication or division is still 0. However if you add code before ulp_entry you end up at the wrong address._

**What do the official docs say?**
`ESP_ERROR_CHECK( ulp_run(&ulp_entry - RTC_SLOW_MEM) );`
[See here](https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/ulp.html)